### PR TITLE
systemd-networkd removed default conf

### DIFF
--- a/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/recipes-core/systemd/systemd-conf_%.bbappend
@@ -1,0 +1,5 @@
+# Removing default systemd network file that take precedence over gwc conf
+
+do_install_append() {
+  rm -f ${D}/lib/systemd/network/*
+}


### PR DESCRIPTION
This is needed to delete `80-wired.network` file installed by `poky/meta/recipes-core/systemd/systemd-conf_244.3.bb`